### PR TITLE
👷 Add Dry Runs to Release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,6 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     defaults:
-      env:
-        DRY_FLAG: ''
       run:
         shell: powershell -Version 4.0 {0}
         working-directory: ./

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,6 @@ jobs:
 
     defaults:
       run:
-        shell: powershell -Version 4.0 {0}
         working-directory: ./
 
     steps:
@@ -45,10 +44,12 @@ jobs:
         run: ci_tools prepare-version --allow-dirty-workdir
 
       - name: 'Setup ps2exe'
+        shell: powershell -Version 4.0 {0}
         working-directory: ./PS2EXE
         run: Install-Module -Scope CurrentUser -Force ps2exe
 
       - name: 'Create exe'
+        shell: powershell -Version 4.0 {0}
         working-directory: ./src
         run: ps2exe -IconFile GW2.ico -InputFile GW2.ps1 -OutputFile "../dist/GW2 Startup Script.exe" -title "GW2 Startup Script" -version ${require('../package.json').version}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,9 +29,6 @@ jobs:
           if_true: ""
           if_false: "--dry"
 
-      - name: 'Test Dry Flag'
-        run: echo "DRY_FLAG=${{ steps.dry.outputs.value }}"
-
       - name: 'Checkout Branch'
         uses: actions/checkout@v2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,18 @@ jobs:
       run:
         shell: powershell -Version 4.0 {0}
         working-directory: ./
+        env:
+          DRY_FLAG: ''
 
     steps:
-      - uses: actions/checkout@v2
+      - name: 'Determine Dry or Release'
+        if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/beta'
+        uses: allenevans/set-env@v1.0.0
+        with:
+          DRY_FLAG: '--dry'
+
+      - name: 'Checkout Branch'
+        uses: actions/checkout@v2
 
       - name: 'Setup Node'
         uses: actions/setup-node@v1
@@ -32,23 +41,14 @@ jobs:
       - name: 'Install CI-Tools'
         run: npm install -g @process-engine/ci_tools@latest
 
-      - name: 'Dry run Prepare Version'
-        run: ci_tools prepare-version --allow-dirty-workdir --dry
-
       - name: 'Prepare Version'
-        run: ci_tools prepare-version --allow-dirty-workdir --only-on-primary-branches
-
-      - name: 'Dry run Commit & tag version'
-        env:
-          GH_USER: ${{ secrets.GH_CI_USER_NAME }}
-          GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
-        run: ci_tools commit-and-tag-version --dry
+        run: ci_tools prepare-version --allow-dirty-workdir ${DRY_FLAG}
 
       - name: 'Commit & tag version'
         env:
           GH_USER: ${{ secrets.GH_CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
-        run: ci_tools commit-and-tag-version --only-on-primary-branches
+        run: ci_tools commit-and-tag-version  ${DRY_FLAG}
 
       - name: 'Setup ps2exe'
         working-directory: ./PS2EXE
@@ -62,18 +62,10 @@ jobs:
         working-directory: ./dist
         run: Compress-Archive "./*" "GW2-Startup-Script.zip"
 
-      - name: 'Dry run Create github release'
-        env:
-          GH_USER: ${{ secrets.GH_CI_USER_NAME }}
-          GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
-        run: |
-          ci_tools update-github-release --dry --use-title-and-text-from-git-tag
-          ci_tools update-github-release --dry --assets dist/GW2-Startup-Script.zip
-
       - name: 'Create github release'
         env:
           GH_USER: ${{ secrets.GH_CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
         run: |
-          ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag
-          ci_tools update-github-release --only-on-primary-branches --assets dist/GW2-Startup-Script.zip
+          ci_tools update-github-release ${DRY_FLAG} --use-title-and-text-from-git-tag
+          ci_tools update-github-release ${DRY_FLAG} --assets dist/GW2-Startup-Script.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: 'Determine Dry or Release'
         if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/beta'
-        uses: allenevans/set-env@v1.0.0
+        uses: allenevans/set-env@v1.1.0
         with:
           DRY_FLAG: '--dry'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,8 +32,17 @@ jobs:
       - name: 'Install CI-Tools'
         run: npm install -g @process-engine/ci_tools@latest
 
+      - name: 'Dry run Prepare Version'
+        run: ci_tools prepare-version --allow-dirty-workdir --dry
+
       - name: 'Prepare Version'
-        run: ci_tools prepare-version --allow-dirty-workdir
+        run: ci_tools prepare-version --allow-dirty-workdir --only-on-primary-branches
+
+      - name: 'Dry run Commit & tag version'
+        env:
+          GH_USER: ${{ secrets.GH_CI_USER_NAME }}
+          GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
+        run: ci_tools commit-and-tag-version --dry
 
       - name: 'Commit & tag version'
         env:
@@ -52,6 +61,14 @@ jobs:
       - name: 'Create zip'
         working-directory: ./dist
         run: Compress-Archive "./*" "GW2-Startup-Script.zip"
+
+      - name: 'Dry run Create github release'
+        env:
+          GH_USER: ${{ secrets.GH_CI_USER_NAME }}
+          GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
+        run: |
+          ci_tools update-github-release --dry --use-title-and-text-from-git-tag
+          ci_tools update-github-release --dry --assets dist/GW2-Startup-Script.zip
 
       - name: 'Create github release'
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,13 +40,7 @@ jobs:
         run: npm install -g @process-engine/ci_tools@latest
 
       - name: 'Prepare Version'
-        run: ci_tools prepare-version $DRY_FLAG --allow-dirty-workdir
-
-      - name: 'Commit & tag version'
-        env:
-          GH_USER: ${{ secrets.GH_CI_USER_NAME }}
-          GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
-        run: ci_tools commit-and-tag-version $DRY_FLAG
+        run: ci_tools prepare-version --allow-dirty-workdir
 
       - name: 'Setup ps2exe'
         working-directory: ./PS2EXE
@@ -60,10 +54,16 @@ jobs:
         working-directory: ./dist
         run: Compress-Archive "./*" "GW2-Startup-Script.zip"
 
+      - name: 'Commit & tag version'
+        env:
+          GH_USER: ${{ secrets.GH_CI_USER_NAME }}
+          GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
+        run: ci_tools commit-and-tag-version ${DRY_FLAG}
+
       - name: 'Create github release'
         env:
           GH_USER: ${{ secrets.GH_CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
         run: |
-          ci_tools update-github-release $DRY_FLAG --use-title-and-text-from-git-tag
-          ci_tools update-github-release $DRY_FLAG --assets dist/GW2-Startup-Script.zip
+          ci_tools update-github-release ${DRY_FLAG} --use-title-and-text-from-git-tag
+          ci_tools update-github-release ${DRY_FLAG} --assets dist/GW2-Startup-Script.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,8 @@ jobs:
           DRY_FLAG: '--dry'
 
       - name: 'Test Dry Flag'
+        env:
+          DRY_FLAG: ${DRY_FLAG}
         run: |
           echo "DRY_FLAG=$DRY_FLAG"
           printenv

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: 'Test Dry Flag'
         run: |
-          echo "DRY_FLAG=${DRY_FLAG}"
+          echo "DRY_FLAG=$DRY_FLAG"
           printenv
 
       - name: 'Checkout Branch'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,12 +60,12 @@ jobs:
         env:
           GH_USER: ${{ secrets.GH_CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
-        run: ci_tools commit-and-tag-version --dry
+        run: ci_tools commit-and-tag-version ${{ steps.dry.outputs.value }}
 
       - name: 'Create github release'
         env:
           GH_USER: ${{ secrets.GH_CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
         run: |
-          ci_tools update-github-release --dry --use-title-and-text-from-git-tag
-          ci_tools update-github-release --dry --assets dist/GW2-Startup-Script.zip
+          ci_tools update-github-release ${{ steps.dry.outputs.value }} --use-title-and-text-from-git-tag
+          ci_tools update-github-release ${{ steps.dry.outputs.value }} --assets dist/GW2-Startup-Script.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: 'Determine Dry or Release'
-        if: ${GITHUB_REF} != 'refs/heads/master' && ${GITHUB_REF} != 'refs/heads/develop' && ${GITHUB_REF} != 'refs/heads/beta'
+        if: $GITHUB_REF != 'refs/heads/master' && $GITHUB_REF != 'refs/heads/develop' && $GITHUB_REF != 'refs/heads/beta'
         uses: allenevans/set-env@v1.0.0
         with:
           DRY_FLAG: '--dry'
@@ -40,13 +40,13 @@ jobs:
         run: npm install -g @process-engine/ci_tools@latest
 
       - name: 'Prepare Version'
-        run: ci_tools prepare-version --allow-dirty-workdir ${DRY_FLAG}
+        run: ci_tools prepare-version $DRY_FLAG --allow-dirty-workdir
 
       - name: 'Commit & tag version'
         env:
           GH_USER: ${{ secrets.GH_CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
-        run: ci_tools commit-and-tag-version  ${DRY_FLAG}
+        run: ci_tools commit-and-tag-version $DRY_FLAG
 
       - name: 'Setup ps2exe'
         working-directory: ./PS2EXE
@@ -65,5 +65,5 @@ jobs:
           GH_USER: ${{ secrets.GH_CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
         run: |
-          ci_tools update-github-release ${DRY_FLAG} --use-title-and-text-from-git-tag
-          ci_tools update-github-release ${DRY_FLAG} --assets dist/GW2-Startup-Script.zip
+          ci_tools update-github-release $DRY_FLAG --use-title-and-text-from-git-tag
+          ci_tools update-github-release $DRY_FLAG --assets dist/GW2-Startup-Script.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,9 +30,7 @@ jobs:
           if_false: "--dry"
 
       - name: 'Test Dry Flag'
-        run: |
-          echo "DRY_FLAG=${{ steps.dry.outputs.value }}"
-          printenv
+        run: echo "DRY_FLAG=${{ steps.dry.outputs.value }}"
 
       - name: 'Checkout Branch'
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,11 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     defaults:
+      env:
+        DRY_FLAG: ''
       run:
         shell: powershell -Version 4.0 {0}
         working-directory: ./
-        env:
-          DRY_FLAG: ''
 
     steps:
       - name: 'Determine Dry or Release'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: 'Determine Dry or Release'
-        if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/beta'
-        uses: allenevans/set-env@v1.1.0
+        id: dry
+        uses: haya14busa/action-cond@v1
         with:
-          DRY_FLAG: '--dry'
+          cond: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/beta' }}
+          if_true: ""
+          if_false: "--dry"
 
       - name: 'Test Dry Flag'
-        env:
-          DRY_FLAG: ${DRY_FLAG}
         run: |
-          echo "DRY_FLAG=$DRY_FLAG"
+          echo "DRY_FLAG=${{ steps.dry.outputs.value }}"
           printenv
 
       - name: 'Checkout Branch'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: 'Determine Dry or Release'
-        if: $GITHUB_REF != 'refs/heads/master' && $GITHUB_REF != 'refs/heads/develop' && $GITHUB_REF != 'refs/heads/beta'
+        if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/beta'
         uses: allenevans/set-env@v1.0.0
         with:
           DRY_FLAG: '--dry'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: 'Determine Dry or Release'
-        if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/beta'
+        if: ${GITHUB_REF} != 'refs/heads/master' && ${GITHUB_REF} != 'refs/heads/develop' && ${GITHUB_REF} != 'refs/heads/beta'
         uses: allenevans/set-env@v1.0.0
         with:
           DRY_FLAG: '--dry'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,11 @@ jobs:
         with:
           DRY_FLAG: '--dry'
 
+      - name: 'Test Dry Flag'
+        run: |
+          echo "DRY_FLAG=${DRY_FLAG}"
+          printenv
+
       - name: 'Checkout Branch'
         uses: actions/checkout@v2
 
@@ -58,12 +63,12 @@ jobs:
         env:
           GH_USER: ${{ secrets.GH_CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
-        run: ci_tools commit-and-tag-version ${DRY_FLAG}
+        run: ci_tools commit-and-tag-version --dry
 
       - name: 'Create github release'
         env:
           GH_USER: ${{ secrets.GH_CI_USER_NAME }}
           GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
         run: |
-          ci_tools update-github-release ${DRY_FLAG} --use-title-and-text-from-git-tag
-          ci_tools update-github-release ${DRY_FLAG} --assets dist/GW2-Startup-Script.zip
+          ci_tools update-github-release --dry --use-title-and-text-from-git-tag
+          ci_tools update-github-release --dry --assets dist/GW2-Startup-Script.zip

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bunjikugashira/gw2_startup_script",
-    "version": "0.1.0-feature-47871c-kdcxmjdg",
+    "version": "0.1.0-feature-a41b90-kdcxy4l3",
     "description": "A script to update ArcDps and then start GW2 and TacO",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bunjikugashira/gw2_startup_script",
-    "version": "0.1.0-alpha.8",
+    "version": "0.1.0-feature-47871c-kdcxmjdg",
     "description": "A script to update ArcDps and then start GW2 and TacO",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bunjikugashira/gw2_startup_script",
-    "version": "0.1.0-alpha.9",
+    "version": "0.1.0-alpha.8",
     "description": "A script to update ArcDps and then start GW2 and TacO",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bunjikugashira/gw2_startup_script",
-    "version": "0.1.0-feature-a41b90-kdcxy4l3",
+    "version": "0.1.0-feature-b50dc7-kdcy6isf",
     "description": "A script to update ArcDps and then start GW2 and TacO",
     "repository": {
         "type": "git",


### PR DESCRIPTION
# Changes
## New Features

1. Add dry runs on minor branches
1. Upgrade powershell version to 7 for all steps except 'Setup ps2exe' and 'Create exe'
1. Fix release ci

# Pull Request
PR: #16
