### PR TITLE
🐛 Fix Script not closing after Monitoring Duration

### DIFF
--- a/src/GW2.ps1
+++ b/src/GW2.ps1
@@ -199,32 +199,31 @@ function ban_current_arc_version() {
 }
 
 function monitor_game_stability() {
-    do {
-        $process_name = [System.IO.Path]::GetFileNameWithoutExtension($GW2_EXE)
-        $process = Get-Process -Name $process_name -ErrorAction SilentlyContinue
+    $process_name = [System.IO.Path]::GetFileNameWithoutExtension($GW2_EXE)
+    $process = Get-Process -Name $process_name -ErrorAction SilentlyContinue
 
-        $exit = $process.WaitForExit($STABILITY_CHECK_SECONDS * 1000)
-        if ($exit) {
-            Write-Verbose "Guild Wars 2 has been closed."
-            $error_message = Get-Process -ErrorAction SilentlyContinue "rundll32" | Where-Object {$_.MainWindowTitle -like "Fehler"}
+    Write-Host "Monitoring game stability for $STABILITY_CHECK_SECONDS seconds..."
+    $exit = $process.WaitForExit($STABILITY_CHECK_SECONDS * 1000)
+    if ($exit) {
+        Write-Verbose "Guild Wars 2 has been closed."
+        $error_message = Get-Process -ErrorAction SilentlyContinue "rundll32" | Where-Object {$_.MainWindowTitle -like "Fehler"}
 
-            if ($error_message) {
-                Write-Verbose "Found error message."
-                Stop-Process $error_message
+        if ($error_message) {
+            Write-Error "Found error message."
+            Stop-Process $error_message
 
-                ban_current_arc_version
-                start_gw2
-                start_taco
+            ban_current_arc_version
+            start_gw2
+            start_taco
 
-                Write-Host "Press any key to exit..."
-                Read-Host
-                return
-            } else {
-                Write-Verbose "No error message."
-                return
-            }
+            Write-Host "Press any key to exit..."
+            Read-Host
+            return
+        } else {
+            Write-Verbose "No error message."
+            return
         }
-    } while (is_running($GW2_EXE, 3))
+    }
 }
 
 function main() {


### PR DESCRIPTION
# Changes
## New Features

1. The script now properly closes after monitoring game stability for the time specified in the config

# Pull Request
PR: #22
